### PR TITLE
Fix templates to match Plone 6 master template

### DIFF
--- a/src/collective/easyform/browser/model_listing.pt
+++ b/src/collective/easyform/browser/model_listing.pt
@@ -3,24 +3,16 @@
 >
   <body>
     <metal:block fill-slot="content">
-      <div id="edit-bar"
-           tal:define="
-             context nocall:context/aq_parent;
-           "
-           tal:content="structure provider:plone.contentviews"
-           tal:on-error="nothing"
-      ></div>
-      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-            Status message
-      </div>
-      <div id="content">
-        <h1 class="documentFirstHeading"
-            tal:content="view/label | nothing"
-        ></h1>
-        <div id="content-core">
-          <span tal:replace="structure view/contents"></span>
-        </div>
-      </div>
+      <metal:content metal:define-macro="content">
+        <article id="content">
+          <h1 class="documentFirstHeading"
+              tal:content="view/label | nothing"
+          ></h1>
+          <div id="content-core">
+            <span tal:replace="structure view/contents"></span>
+          </div>
+        </article>
+      </metal:content>
     </metal:block>
   </body>
 </html>

--- a/src/collective/easyform/browser/modeleditor.pt
+++ b/src/collective/easyform/browser/modeleditor.pt
@@ -9,9 +9,9 @@
 >
 
   <body>
-    <metal:main fill-slot="content">
-      <tal:main-macro metal:define-macro="content">
-        <div id="content">
+    <metal:block fill-slot="content">
+      <metal:content metal:define-macro="content">
+        <article id="content">
           <style type="text/css"
                  tal:content="string:@import url(${portal_url}/++resource++plone.app.dexterity.modeleditor.css);"
           ></style>
@@ -56,8 +56,8 @@
             </form>
           </div>
 
-        </div>
-      </tal:main-macro>
-    </metal:main>
+        </article>
+      </metal:content>
+    </metal:block>
   </body>
 </html>


### PR DESCRIPTION
The current `@@fields`, `@@actions` forms and the related modelleditor views fill the `content` slot of the master template, which is changed with Plone 6.

> Please note that this template fills the "content" slot instead of the "main" slot, this is done so we can provide stuff like the content tabs. This also means that we have to supply things that are normally present from main_template. [[source]](https://github.com/plone/Products.CMFPlone/blob/6.0.11/Products/CMFPlone/browser/templates/author.pt#L18-L23)

The `model_listing.pt` also inserts additional `#edit-bar` div and a duplicate portal message. See it on https://classic.demo.plone.org/ by creating an EasyForm, and opening the fields actions. A search for `#edit-bar` in the console will have multiple results. The duplicate portal message does not show up, since the master template one already dumps the messages.

![image](https://github.com/user-attachments/assets/bc7b11b2-7d54-402a-a727-5ddaa0b92fec)

The proposed changes remove the duplicate edit bar and portal messages, while updating the templates to match [Plone 6 master template](https://github.com/plone/Products.CMFPlone/blob/6.0.11/Products/CMFPlone/browser/templates/main_template.pt#L79-L85).